### PR TITLE
Fix/#30 백스택 버그 픽스

### DIFF
--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/home/HomeScreen.kt
@@ -71,7 +71,7 @@ fun HomeScreen(
 
     BackHandler(enabled = true) {
         if (backPressedOnce) {
-            (context as? Activity)?.finish()
+            (context as? Activity)?.finishAffinity()
         } else {
             backPressedOnce = true
             Toast.makeText(context, R.string.back_provider_toast_text, Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## 관련 이슈 
- Resolved : #30 

## 작업 내용
- 홈 스크린에서 뒤로가기 시, 백스택 상관 없이 앱 종료

2회 이상 타이머 실행 시, 개수만큼 쌓이지는 않음 (1개만 쌓임)
근본적인 해결은 아닌 듯하지만, 달리 방안도 없는 듯 함

## 🚨 참고 사항
<!-- 주의 깊게 봐야할 내용 --> 
<!-- 논의 내용 -->
<!-- 참고 자료들 리스트업 -->

## 📷 스크린샷
|기능|
|:--:|
|<!-- 이미지 첨부 자리 -->|
