### PR TITLE
Fix/#55 refactor stcker

### DIFF
--- a/app/src/main/java/com/ggaebiz/ggaebiz/data/repository/ImageRepositoryImpl.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/data/repository/ImageRepositoryImpl.kt
@@ -3,20 +3,13 @@ package com.ggaebiz.ggaebiz.data.repository
 import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Matrix
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.unit.IntSize
 import androidx.core.content.FileProvider
 import com.ggaebiz.ggaebiz.domain.repository.ImageRepository
-import com.ggaebiz.ggaebiz.presentation.model.Sticker
-import com.ggaebiz.ggaebiz.presentation.model.StickerSource
-import com.ggaebiz.ggaebiz.presentation.ui.proof.loadBitmapFromUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -25,26 +18,10 @@ class ImageRepositoryImpl(
     private val appContext: Context
 ) : ImageRepository {
 
-    override suspend fun createCachedImage(
-        background: ImageBitmap,
-        canvasSize: IntSize,
-        stickers: List<Sticker>
-    ): Uri {
-
-        val backgroundBitmap = background.asAndroidBitmap()
-
-        val mergedBitmap = withContext(Dispatchers.Default) {
-            createShareBitmap(
-                background = backgroundBitmap,
-                canvasSize = canvasSize,
-                stickers = stickers
-            )
+    override suspend fun createCachedImage(bitmap: ImageBitmap): Uri =
+        withContext(Dispatchers.IO) {
+            saveBitmapToCache(bitmap.asAndroidBitmap())
         }
-
-        return withContext(Dispatchers.IO) {
-            saveBitmapToCache(mergedBitmap)
-        }
-    }
 
     override suspend fun saveImageToGallery(uri: Uri): Result<Unit> =
         withContext(Dispatchers.IO) {
@@ -53,61 +30,6 @@ class ImageRepositoryImpl(
             }
         }
 
-    override suspend fun createProofCard(
-        bitmap: ImageBitmap
-    ): Uri = withContext(Dispatchers.IO) {
-        val androidBitmap = bitmap.asAndroidBitmap()
-        saveBitmapToCache(androidBitmap)
-    }
-
-
-    private fun createShareBitmap(
-        background: Bitmap,
-        canvasSize: IntSize,
-        stickers: List<Sticker>
-    ): Bitmap {
-
-        val result = Bitmap.createBitmap(
-            background.width,
-            background.height,
-            Bitmap.Config.ARGB_8888
-        )
-
-        val canvas = Canvas(result)
-        canvas.drawBitmap(background, 0f, 0f, null)
-
-        val scaleFactor =
-            background.width.toFloat() / canvasSize.width.toFloat()
-
-        stickers
-            .sortedBy { it.zIndex }
-            .forEach { sticker ->
-                when(sticker.source){
-                    is StickerSource.Bitmap -> {
-                        val stickerBitmap = (sticker.source as StickerSource.Bitmap).image.asAndroidBitmap()
-                        val cx = sticker.x * scaleFactor
-                        val cy = sticker.y * scaleFactor
-
-                        val matrix = Matrix().apply {
-                            postTranslate(
-                                -stickerBitmap.width / 2f,
-                                -stickerBitmap.height / 2f
-                            )
-                            postScale(
-                                sticker.scale * scaleFactor,
-                                sticker.scale * scaleFactor
-                            )
-                            postRotate(sticker.rotation)
-                            postTranslate(cx, cy)
-                        }
-                        canvas.drawBitmap(stickerBitmap, matrix, null)
-                    }
-                    else-> {}
-                }
-            }
-
-        return result
-    }
 
     /**
      * cacheDir 에 파일 저장

--- a/app/src/main/java/com/ggaebiz/ggaebiz/domain/repository/ImageRepository.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/domain/repository/ImageRepository.kt
@@ -2,20 +2,10 @@ package com.ggaebiz.ggaebiz.domain.repository
 
 import android.net.Uri
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.unit.IntSize
-import com.ggaebiz.ggaebiz.presentation.model.Sticker
 
 interface ImageRepository {
 
-    suspend fun createCachedImage(
-        background: ImageBitmap,
-        canvasSize: IntSize,
-        stickers: List<Sticker>
-    ): Uri
+    suspend fun createCachedImage(bitmap: ImageBitmap): Uri
 
     suspend fun saveImageToGallery(uri: Uri): Result<Unit>
-    
-    suspend fun createProofCard(
-        bitmap: ImageBitmap
-    ): Uri
 }

--- a/app/src/main/java/com/ggaebiz/ggaebiz/domain/usecase/CreateCachedResultImageUseCase.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/domain/usecase/CreateCachedResultImageUseCase.kt
@@ -2,27 +2,12 @@ package com.ggaebiz.ggaebiz.domain.usecase
 
 import android.net.Uri
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.unit.IntSize
 import com.ggaebiz.ggaebiz.domain.repository.ImageRepository
-import com.ggaebiz.ggaebiz.presentation.model.Sticker
 
 class CreateCachedImageUseCase(
     private val imageRepository: ImageRepository
 ) {
-    suspend operator fun invoke(
-        background: ImageBitmap,
-        canvasSize: IntSize,
-        stickers: List<Sticker>
-    ): Uri {
-        return imageRepository.createCachedImage(
-            background,
-            canvasSize,
-            stickers
-        )
-    }
-    suspend fun createProofCard(
-        bitmap: ImageBitmap
-    ): Uri {
-        return imageRepository.createProofCard(bitmap)
+    suspend operator fun invoke(bitmap: ImageBitmap): Uri {
+        return imageRepository.createCachedImage(bitmap)
     }
 }

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/model/Sticker.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/model/Sticker.kt
@@ -2,34 +2,17 @@ package com.ggaebiz.ggaebiz.presentation.model
 
 import androidx.annotation.DrawableRes
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.vector.ImageVector
+import java.util.UUID
 
-sealed interface Sticker {
-    val id: String
-    val x: Float get() = offset.x   // 파생
-    val y: Float get() = offset.y
-    val scale: Float
-    val zIndex: Int
-    val offset: Offset       // 중심 기준
-    val isSelected: Boolean
-    var rotation: Float
+data class Sticker(
+    val id: String = UUID.randomUUID().toString(),
+    val offset: Offset,
+    val scale: Float = 1f,
+    val rotation: Float = 0f,
+    val zIndex: Int = 0,
     val source: StickerSource
-}
-
-data class BitmapSticker(
-    override val id: String = java.util.UUID.randomUUID().toString(),
-    override val x: Float,
-    override val y: Float,
-    override val offset: Offset,
-    override val scale: Float = 1f,
-    override val zIndex: Int = 0,
-    override val isSelected: Boolean = false,
-    override var rotation: Float = 0f,
-    override val source: StickerSource.Bitmap
-) : Sticker
+)
 
 sealed interface StickerSource {
-    data class Png(@DrawableRes val resId: Int): StickerSource
-    data class Bitmap(val image: ImageBitmap) : StickerSource
+    data class Png(@DrawableRes val resId: Int) : StickerSource
 }

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/Component.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/Component.kt
@@ -25,35 +25,30 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.ggaebiz.ggaebiz.R
 import com.ggaebiz.ggaebiz.presentation.designsystem.theme.GaeBizTheme
-import com.ggaebiz.ggaebiz.presentation.model.BitmapSticker
 import com.ggaebiz.ggaebiz.presentation.model.Sticker
 import com.ggaebiz.ggaebiz.presentation.model.StickerSource
 import kotlin.math.PI
-import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
 
 @Composable
 fun Segmented2Tabs(
@@ -121,213 +116,158 @@ private fun Pill(
 }
 
 
-
-
 @Composable
 fun StickersCanvas(
     canvasSize: IntSize,
     stickers: List<Sticker>,
     selectedId: String?,
     onSelect: (String) -> Unit,
-    onBringToFront: (String) -> Unit,
     onMove: (id: String, x: Float, y: Float) -> Unit,
+    onScale: (id: String, scale: Float) -> Unit,
+    onRotate: (id: String, angleDelta: Float) -> Unit,
     onRemove: (id: String) -> Unit,
-    onTransform: (
-        id: String,
-        pan: Offset,
-        zoom: Float?,
-        rotation: Float?,
-    ) -> Unit,
-    edgeOverdrag: Dp = 0.dp,
-    onDragActiveChange: (Boolean) -> Unit = {},
 ) {
     val density = LocalDensity.current
-    val baseSizeDp = 120.dp
-    val baseSizePx = with(density) { baseSizeDp.toPx() }
-    val overPx = with(density) { edgeOverdrag.toPx() }
+    val baseSizePx = with(density) { 120.dp.toPx() }
 
     stickers.forEach { s ->
-        val isSel = s.id == selectedId
-        val currW = baseSizePx * s.scale
-        val currH = baseSizePx * s.scale
-        val halfW = currW / 2f
-        val halfH = currH / 2f
+        key(s.id) {
+            val isSelected = s.id == selectedId
+            val sizePx = baseSizePx * s.scale
+            val sizeDp = with(density) { sizePx.toDp() }
 
-        val minX = halfW - overPx
-        val maxX = canvasSize.width - halfW + overPx
-        val minY = halfH - overPx
-        val maxY = canvasSize.height - halfH + overPx
-
-        val minXState by rememberUpdatedState(minX)
-        val maxXState by rememberUpdatedState(maxX)
-        val minYState by rememberUpdatedState(minY)
-        val maxYState by rememberUpdatedState(maxY)
-
-        Box(
-            modifier = Modifier
-                .graphicsLayer {
-                    translationX = s.x - halfW
-                    translationY = s.y - halfH
-                    scaleX = s.scale
-                    scaleY = s.scale
-                    rotationZ = s.rotation
-                }
-                .size(baseSizeDp * s.scale)
-                .pointerInput(s.id) {
-                    var startX = 0f
-                    var startY = 0f
-                    var accX = 0f
-                    var accY = 0f
-                    detectDragGestures(
-                        onDragStart = {
-                            onSelect(s.id)
-                            onBringToFront(s.id)
-                            startX = s.x
-                            startY = s.y
-                            accX = 0f
-                            accY = 0f
-                            onDragActiveChange(true)
-                        },
-                        onDragEnd = { onDragActiveChange(false) },
-                        onDragCancel = { onDragActiveChange(false) },
-                        onDrag = { change, drag ->
-                            change.consume()
-                            accX += drag.x
-                            accY += drag.y
-                            val nx = (startX + accX).coerceIn(minXState, maxXState)
-                            val ny = (startY + accY).coerceIn(minYState, maxYState)
-                            onMove(s.id, nx, ny)
-                        }
-                    )
-                }
-        ) {
-            when (s) {
-                is BitmapSticker -> Image(
-                    bitmap = s.source.image,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Fit
-                )
-            }
-
-            if (isSel) {
-                val borderW = 1.dp
-                val delHandleSize = 20.dp
-                val resizeHandleSize = 24.dp
-                val innerBiasDp = 4.dp
-
-                val halfBorderPx = with(density) { (borderW / 2).toPx() }
-                val halfDelPx = with(density) { (delHandleSize / 2).toPx() }
-                val halfResizePx = with(density) { (resizeHandleSize / 2).toPx() }
-                val innerBiasPx = with(density) { innerBiasDp.toPx() }
-
-                Box(
-                    Modifier
-                        .matchParentSize()
-                        .border(borderW, GaeBizTheme.colors.white)
-                )
-
-                var startScale by remember { mutableStateOf(1f) }
-                var startRotation by remember { mutableStateOf(0f) }
-                var startAngle by remember { mutableStateOf(0f) }
-                var lastAngle by remember { mutableStateOf(0f) }
-                Box(
-                    Modifier
-                        .size(resizeHandleSize)
-                        .align(Alignment.BottomEnd)
-                        .offset {
-                            IntOffset(
-                                (halfResizePx + halfBorderPx - innerBiasPx).toInt(),
-                                (halfResizePx + halfBorderPx - innerBiasPx).toInt()
-                            )
-                        }
-                        .background(GaeBizTheme.colors.white, CircleShape)
-                        .pointerInput(s.id) {
-                            detectDragGestures(
-                                onDragStart = { down ->
-                                    onSelect(s.id)
-                                    onBringToFront(s.id)
-
-                                    startScale = s.scale
-                                    startRotation = s.rotation
-
-                                    val center = Offset(s.x, s.y)
-                                    val touch = center + down
-
-                                    startAngle = atan2(
-                                        touch.y - center.y,
-                                        touch.x - center.x
-                                    )
-                                },
-                                onDrag = { change, drag ->
-                                    change.consume()
-
-                                    // 스케일
-                                    val deltaScale = (drag.x + drag.y) / 200f
-                                    val newScale =
-                                        (startScale + deltaScale).coerceAtLeast(0.1f)
-
-                                    // 각도
-                                    val center = Offset(s.x, s.y)
-                                    val touch = center + change.position
-
-                                    val currentAngle = atan2(
-                                        touch.y - center.y,
-                                        touch.x - center.x
-                                    )
-
-
-                                    val ROTATION_SENSITIVITY = 0.5f  // 회전 감도
-                                    val angleDelta =
-                                        -(currentAngle - startAngle) *
-                                                ROTATION_SENSITIVITY *
-                                                180f / PI.toFloat()
-
-
-                                    val newRotation =
-                                        (startRotation + angleDelta).mod(360f)
-
-                                    // 한번에 전달
-                                    onTransform(
-                                        s.id,
-                                        Offset.Zero,
-                                        newScale,
-                                        newRotation
-                                    )
-                                }
-                            )
-                        },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.icon_image_resize),
+            val currentOffset by rememberUpdatedState(s.offset)
+            val currentScale by rememberUpdatedState(s.scale)
+            val currentRotation by rememberUpdatedState(s.rotation)
+            Box(
+                modifier = Modifier
+                    .offset {
+                        IntOffset(
+                            (s.offset.x - sizePx / 2f).toInt(),
+                            (s.offset.y - sizePx / 2f).toInt()
+                        )
+                    }
+                    .size(sizeDp)
+                    .graphicsLayer { rotationZ = s.rotation }
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) {
+                        onSelect(s.id)
+                    }
+                    .pointerInput(s.id) {
+                        var startX = 0f
+                        var startY = 0f
+                        var accX = 0f
+                        var accY = 0f
+                        detectDragGestures(
+                            onDragStart = {
+                                onSelect(s.id)
+                                startX = currentOffset.x
+                                startY = currentOffset.y
+                                accX = 0f
+                                accY = 0f
+                            },
+                            onDrag = { change, delta ->
+                                change.consume()
+                                accX += delta.x
+                                accY += delta.y
+                                val nx = (startX + accX)
+                                    .coerceIn(0f, canvasSize.width.toFloat())
+                                val ny = (startY + accY)
+                                    .coerceIn(0f, canvasSize.height.toFloat())
+                                onMove(s.id, nx, ny)
+                            }
+                        )
+                    }
+            ) {
+                when (s.source) {
+                    is StickerSource.Png -> Image(
+                        painter = painterResource(id = s.source.resId),
                         contentDescription = null,
-                        tint = Color.Black,
-                        modifier = Modifier.size(12.dp)
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Fit
                     )
                 }
 
-                // 좌상단: 삭제
-                Box(
-                    Modifier
-                        .size(delHandleSize)
-                        .align(Alignment.TopStart)
-                        .offset {
-                            IntOffset(
-                                -(halfDelPx + halfBorderPx).toInt(),
-                                -(halfDelPx + halfBorderPx).toInt()
-                            )
-                        }
-                        .background(GaeBizTheme.colors.white, CircleShape)
-                        .clickable { onRemove(s.id) },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.icon_image_delete),
-                        contentDescription = null,
-                        tint = Color.Black,
-                        modifier = Modifier.size(10.dp)
+                if (isSelected) {
+                    val handleSize = 24.dp
+                    val handleOffset = 8.dp
+
+                    // 선택 테두리
+                    Box(
+                        Modifier
+                            .matchParentSize()
+                            .border(1.dp, GaeBizTheme.colors.white)
                     )
+
+                    // 좌상단: 삭제
+                    Box(
+                        Modifier
+                            .size(handleSize)
+                            .align(Alignment.TopStart)
+                            .offset(x = -handleOffset, y = -handleOffset)
+                            .background(GaeBizTheme.colors.white, CircleShape)
+                            .clickable { onRemove(s.id) },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.icon_image_delete),
+                            contentDescription = null,
+                            tint = Color.Black,
+                            modifier = Modifier.size(12.dp)
+                        )
+                    }
+
+                    // 우하단: 리사이즈 + 회전
+                    Box(
+                        Modifier
+                            .size(handleSize)
+                            .align(Alignment.BottomEnd)
+                            .offset(x = handleOffset, y = handleOffset)
+                            .background(GaeBizTheme.colors.white, CircleShape)
+                            .pointerInput(s.id) {
+                                var startScale = 1f
+                                var accRadial = 0f
+                                detectDragGestures(
+                                    onDragStart = {
+                                        startScale = currentScale
+                                        accRadial = 0f
+                                    },
+                                    onDrag = { change, delta ->
+                                        change.consume()
+                                        // 화면 좌표 → 스티커 로컬 좌표 변환 (회전 보정)
+                                        val rot = currentRotation * (PI.toFloat() / 180f)
+                                        val cosR = cos(rot)
+                                        val sinR = sin(rot)
+                                        val localDx = delta.x * cosR + delta.y * sinR
+                                        val localDy = -delta.x * sinR + delta.y * cosR
+
+                                        // 방사형 (NW↔SE): 크기 조절
+                                        val radial = (localDx + localDy) / 2f
+                                        accRadial += radial
+                                        val newScale = (startScale + accRadial / baseSizePx)
+                                            .coerceIn(0.3f, 5f)
+                                        onScale(s.id, newScale)
+
+                                        // 접선형 (수직 방향): 회전
+                                        val tangential = (-localDx + localDy) / 2f
+                                        val halfDiag = baseSizePx * currentScale * 0.7f
+                                        val angleDelta =
+                                            tangential / halfDiag * (180f / PI.toFloat())
+                                        onRotate(s.id, angleDelta)
+                                    }
+                                )
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.icon_image_resize),
+                            contentDescription = null,
+                            tint = Color.Black,
+                            modifier = Modifier.size(12.dp)
+                        )
+                    }
                 }
             }
         }
@@ -359,13 +299,11 @@ fun StickerPickerGrid(
             ) {
                 when (src) {
                     is StickerSource.Png -> Image(
-                        bitmap = ImageBitmap.imageResource(id = src.resId),
+                        painter = painterResource(id = src.resId),
                         contentDescription = null,
                         modifier = Modifier.fillMaxSize(),
                         contentScale = ContentScale.Fit
                     )
-
-                    else -> {}
                 }
             }
         }

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/card/ProofCardViewModel.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/card/ProofCardViewModel.kt
@@ -76,7 +76,7 @@ class ProofCardViewModel(
 
     private fun createAndSaveImage() = launch {
         val uri = uiState.value.previewBitmap?.let {
-            createProofCardUseCase.createProofCard(it)
+            createProofCardUseCase(it)
         }
         uri?.let {
             saveImageToGalleryUseCase(it)
@@ -93,7 +93,7 @@ class ProofCardViewModel(
 
     private fun createAndShareImage() = launch {
         val uri = uiState.value.previewBitmap?.let {
-            createProofCardUseCase.createProofCard(it)
+            createProofCardUseCase(it)
         }
         uri?.let {
             postSideEffect(ProofCardSideEffect.ShareImage(it))

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorContract.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorContract.kt
@@ -1,9 +1,7 @@
 package com.ggaebiz.ggaebiz.presentation.ui.proof.editor
 
 import android.content.Context
-import android.content.res.Resources
 import android.net.Uri
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.IntSize
 import com.ggaebiz.ggaebiz.R
@@ -38,33 +36,27 @@ data class EditorState(
             StickerSource.Png(R.drawable.sticker_17),
             StickerSource.Png(R.drawable.sticker_18)
         ),
-    val timeStampResource : List<StickerSource> = emptyList()
+    val timeStampResource : List<StickerSource> = emptyList(),
 ){
     val nowSource = if (selectTab == SelectTab.STICKER) stickerSources else timeStampResource
 }
 
 sealed interface EditorIntent {
     data class OnLoadImageData(val context: Context, val imageUri: Uri) : EditorIntent
-    data class ClickFinish(val canvasSize: IntSize) : EditorIntent
+    data class ClickFinish(val capturedBitmap: ImageBitmap) : EditorIntent
     data object ClickBack : EditorIntent
     data class ChangeTab(val tab : SelectTab) : EditorIntent
-    data class OnPick(val source : StickerSource, val canvasSize : IntSize, val resource : Resources) :
-        EditorIntent
-    data class OnSelectImage(val selectImageId: String) : EditorIntent
-    data class OnTransform(
-        val id: String,
-        val pan: Offset,
-        val zoom: Float? = null,
-        val rotation: Float? = null
-    ) : EditorIntent
 
+    // 스티커 선택해서 추가
+    data class OnPick(val source : StickerSource, val canvasSize : IntSize) : EditorIntent
+
+    // 현재 핸들링하는 스티커로 선택 + 최상위로 이동
+    data class OnSelectImage(val selectImageId: String) : EditorIntent
     data class OnMove(val id : String, val x : Float, val y : Float): EditorIntent
-    data class OnResize(val id : String , val scale: Float ): EditorIntent
     data class OnRemove(val id : String): EditorIntent
     data class OnRotate(val id : String, val newRotation: Float): EditorIntent
-    data class OnBringToFront(val id : String): EditorIntent
+    data class OnScale(val id: String, val scale: Float) : EditorIntent
 }
-
 
 
 sealed interface EditorEffect {

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorScreen.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorScreen.kt
@@ -137,14 +137,15 @@ fun PhotoEditorScreen(
             )
         },
         sheetContent = {
-            Segmented2Tabs(
-                left = "타임 스탬프",
-                right = "스티커",
-                selectedRight = uiState.selectTab == SelectTab.STICKER,
-                onSelectLeft = { processIntent(EditorIntent.ChangeTab(SelectTab.TIME_STAMP)) },
-                onSelectRight = { processIntent(EditorIntent.ChangeTab(SelectTab.STICKER)) },
-                modifier = Modifier.padding(top = 8.dp)
-            )
+            // TODO: 타임스탬프 기능 추가 시 주석 해제
+            // Segmented2Tabs(
+            //     left = "타임 스탬프",
+            //     right = "스티커",
+            //     selectedRight = uiState.selectTab == SelectTab.STICKER,
+            //     onSelectLeft = { processIntent(EditorIntent.ChangeTab(SelectTab.TIME_STAMP)) },
+            //     onSelectRight = { processIntent(EditorIntent.ChangeTab(SelectTab.STICKER)) },
+            //     modifier = Modifier.padding(top = 8.dp)
+            // )
             StickerPickerGrid(
                 sources = uiState.nowSource,
                 onPick = { src ->

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorScreen.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
@@ -40,6 +43,7 @@ import com.ggaebiz.ggaebiz.presentation.designsystem.theme.GaeBizTheme
 import com.ggaebiz.ggaebiz.presentation.ui.proof.Segmented2Tabs
 import com.ggaebiz.ggaebiz.presentation.ui.proof.StickerPickerGrid
 import com.ggaebiz.ggaebiz.presentation.ui.proof.StickersCanvas
+import kotlinx.coroutines.delay
 import org.koin.androidx.compose.koinViewModel
 
 
@@ -85,7 +89,17 @@ fun PhotoEditorScreen(
 
     val scaffoldState = rememberBottomSheetScaffoldState()
     var canvasSize by remember { mutableStateOf(IntSize(1, 1)) }
-    var dragging by remember { mutableStateOf(false) }
+    val graphicsLayer = rememberGraphicsLayer()
+    var isCapturing by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isCapturing) {
+        if (isCapturing) {
+            delay(100)
+            val bitmap = graphicsLayer.toImageBitmap()
+            isCapturing = false
+            processIntent(EditorIntent.ClickFinish(bitmap))
+        }
+    }
 
     BottomSheetScaffold(
         scaffoldState = scaffoldState,
@@ -99,7 +113,7 @@ fun PhotoEditorScreen(
                             .clip(RoundedCornerShape(10.dp))
                             .background(GaeBizTheme.colors.primaryOrange)
                             .clickable {
-                                processIntent(EditorIntent.ClickFinish(canvasSize))
+                                isCapturing = true
                             }
                             .padding(horizontal = 20.dp, vertical = 12.dp),
                         contentAlignment = Alignment.Center
@@ -137,8 +151,7 @@ fun PhotoEditorScreen(
                     processIntent(
                         EditorIntent.OnPick(
                             canvasSize = canvasSize,
-                            source = src,
-                            resource = context.resources
+                            source = src
                         )
                     )
                 }
@@ -163,7 +176,17 @@ fun PhotoEditorScreen(
                             .fillMaxWidth()
                             .aspectRatio(3f / 4f)
                             .background(Color.Black, RoundedCornerShape(12.dp))
-                            .onGloballyPositioned { canvasSize = it.size },
+                            .onGloballyPositioned { canvasSize = it.size }
+                            .drawWithContent {
+                                if (isCapturing) {
+                                    graphicsLayer.record {
+                                        this@drawWithContent.drawContent()
+                                    }
+                                    drawLayer(graphicsLayer)
+                                } else {
+                                    drawContent()
+                                }
+                            },
                     ) {
                         Image(
                             bitmap = uiState.previewBitmap,
@@ -174,20 +197,19 @@ fun PhotoEditorScreen(
                         StickersCanvas(
                             canvasSize = canvasSize,
                             stickers = uiState.stickers.sortedBy { it.zIndex },
-                            selectedId = uiState.selectImageId,
+                            selectedId = if (isCapturing) null else uiState.selectImageId,
                             onSelect = { id -> processIntent(EditorIntent.OnSelectImage(id)) },
-                            onBringToFront = { id ->
-                                processIntent(EditorIntent.OnBringToFront(id))
-                            },
                             onMove = { id, nx, ny ->
                                 processIntent(EditorIntent.OnMove(id, nx, ny))
                             },
+                            onScale = { id, scale ->
+                                processIntent(EditorIntent.OnScale(id, scale))
+                            },
+                            onRotate = { id, angle ->
+                                processIntent(EditorIntent.OnRotate(id, angle))
+                            },
                             onRemove = { id ->
                                 processIntent(EditorIntent.OnRemove(id))
-                            },
-                            onDragActiveChange = { dragging = it },  //  드래그 중 시트 스와이프 OFF,
-                            onTransform = { id, pan, zoom, rotation ->
-                                processIntent(EditorIntent.OnTransform(id,pan,zoom,rotation))
                             }
                         )
                     }

--- a/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorViewModel.kt
+++ b/app/src/main/java/com/ggaebiz/ggaebiz/presentation/ui/proof/editor/EditorViewModel.kt
@@ -1,19 +1,14 @@
 package com.ggaebiz.ggaebiz.presentation.ui.proof.editor
 
-import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import com.ggaebiz.ggaebiz.domain.usecase.CreateCachedImageUseCase
 import com.ggaebiz.ggaebiz.presentation.common.base.BaseViewModel
-import com.ggaebiz.ggaebiz.presentation.model.BitmapSticker
 import com.ggaebiz.ggaebiz.presentation.model.Sticker
-import com.ggaebiz.ggaebiz.presentation.model.StickerSource
 import com.ggaebiz.ggaebiz.presentation.ui.proof.loadBitmapFromUri
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class EditorViewModel(
@@ -26,157 +21,106 @@ class EditorViewModel(
 ) {
     fun processIntent(intent: EditorIntent) {
         when (intent) {
-            is EditorIntent.OnLoadImageData -> {
-                viewModelScope.launch {
-                    withContext(Dispatchers.IO) {
-                        runCatching {
-                            loadBitmapFromUri(
-                                intent.context,
-                                intent.imageUri,
-                                reqWidth = null,
-                                reqHeight = null
-                            ).asImageBitmap()
-                        }.onSuccess { bitmap ->
-                            updateState { it.copy(previewBitmap = bitmap) }
-                        }.onFailure {
-                            updateState { it.copy(isImageLoadError = true) }
-                        }
-                    }
-                }
-            }
+            is EditorIntent.OnLoadImageData -> loadImageData(intent)
+            is EditorIntent.ClickFinish -> finishEditing(intent)
+            is EditorIntent.ClickBack -> {}
+            is EditorIntent.ChangeTab -> updateState { it.copy(selectTab = intent.tab) }
+            is EditorIntent.OnPick -> addSticker(intent)
+            is EditorIntent.OnSelectImage -> selectSticker(intent)
+            is EditorIntent.OnMove -> moveSticker(intent)
+            is EditorIntent.OnRemove -> removeSticker(intent)
+            is EditorIntent.OnScale -> scaleSticker(intent)
+            is EditorIntent.OnRotate -> rotateSticker(intent)
+        }
+    }
 
-            EditorIntent.ClickBack -> {
-            }
-
-            is EditorIntent.ClickFinish -> {
-                viewModelScope.launch {
-                    val uri = uiState.value.previewBitmap?.let {
-                        createCachedImageUseCase(
-                            background = it,
-                            canvasSize = intent.canvasSize,
-                            stickers = uiState.value.stickers
-                        )
-                    }
-                    uri?.let { EditorEffect.NavigateToSaveImage(it) }?.let { postSideEffect(it) }
-                }
-            }
-
-            is EditorIntent.ChangeTab -> {
-                updateState { it.copy(selectTab = intent.tab) }
-            }
-
-            is EditorIntent.OnPick -> {
-                val center = Offset(
-                    intent.canvasSize.width / 2f,
-                    intent.canvasSize.height / 2f
-                )
-
-                when (intent.source) {
-                    is StickerSource.Png -> {
-                        val imageBitmap = BitmapFactory
-                            .decodeResource(intent.resource, intent.source.resId)
-                            .asImageBitmap()
-
-                        updateState { state ->
-                            state.copy(
-                                stickers = state.stickers + BitmapSticker(
-                                    offset = center,
-                                    source = StickerSource.Bitmap(imageBitmap),
-                                    zIndex = (state.stickers.maxOfOrNull { it.zIndex } ?: 0) + 1,
-                                    x = center.x,
-                                    y = center.y
-                                )
-                            )
-                        }
-                    }
-                    else -> Unit
-                }
-            }
-
-            is EditorIntent.OnTransform -> {
-                updateState { state ->
-                    state.copy(
-                        stickers = state.stickers.map { s ->
-                            if (s.id != intent.id) s
-                            else when (s) {
-                                is BitmapSticker -> s.copy(
-                                    offset = s.offset + intent.pan,
-                                    scale = intent.zoom ?: s.scale,
-                                    rotation = intent.rotation ?: s.rotation
-                                )
-                            }
-                        }
-                    )
-                }
-            }
-
-
-
-            is EditorIntent.OnSelectImage -> {
-                updateState { it.copy(selectImageId = intent.selectImageId) }
-            }
-
-            is EditorIntent.OnMove -> {
-                updateState {
-                    it.copy(stickers = uiState.value.stickers.map {
-                        if (it.id == intent.id) it.withPos(
-                            intent.x,
-                            intent.y
-                        ) else it
-                    })
-                }
-            }
-
-            is EditorIntent.OnRemove -> {
-                updateState { it.copy(stickers = uiState.value.stickers.filterNot { it.id == intent.id })}
-                if (uiState.value.selectImageId == intent.id) {
-                    updateState { it.copy(selectImageId = null) }
-                }
-            }
-            is EditorIntent.OnResize -> {
-                updateState { state ->
-                    state.copy(stickers = uiState.value.stickers.map {
-                        if (it.id == intent.id) it.withScale(
-                            intent.scale
-                        ) else it
-                    })
-                }
-            }
-            is EditorIntent.OnRotate -> {
-                updateState { state ->
-                    state.copy(stickers = uiState.value.stickers.map {
-                        if (it.id == intent.id) it.withRotation(
-                            it.rotation + intent.newRotation
-                        ) else it
-                    })
-                }
-            }
-            is EditorIntent.OnBringToFront -> {
-                val newTop = (uiState.value.stickers.maxOfOrNull { it.zIndex } ?: 0) + 1
-                updateState { state ->
-                    state.copy(stickers = uiState.value.stickers.map {
-                        if (it.id == intent.id) it.withZ(
-                            newTop
-                        ) else it
-                    })
-                }
+    private fun loadImageData(intent: EditorIntent.OnLoadImageData) = launch {
+        withContext(Dispatchers.IO) {
+            runCatching {
+                loadBitmapFromUri(
+                    intent.context,
+                    intent.imageUri,
+                    reqWidth = null,
+                    reqHeight = null
+                ).asImageBitmap()
+            }.onSuccess { bitmap ->
+                updateState { it.copy(previewBitmap = bitmap) }
+            }.onFailure {
+                updateState { it.copy(isImageLoadError = true) }
             }
         }
     }
 
-    /** 스티커 조작용 확장 , 혹여 벡터를 체크해야하는 일이 올까봐 .. */
-    private fun Sticker.withPos(x: Float, y: Float) = when (this) {
-        is BitmapSticker -> copy(x = x, y = y)
-    }
-    private fun Sticker.withScale(scale: Float) = when (this) {
-        is BitmapSticker -> copy(scale = scale.coerceIn(0.3f, 5f))
+    private fun finishEditing(intent: EditorIntent.ClickFinish) = launch {
+        val uri = createCachedImageUseCase(intent.capturedBitmap)
+        postSideEffect(EditorEffect.NavigateToSaveImage(uri))
     }
 
-    private fun Sticker.withZ(z: Int) = when (this) {
-        is BitmapSticker -> copy(zIndex = z)
+    private fun addSticker(intent: EditorIntent.OnPick) {
+        val center = Offset(
+            intent.canvasSize.width / 2f,
+            intent.canvasSize.height / 2f
+        )
+        updateState { state ->
+            state.copy(
+                stickers = state.stickers + Sticker(
+                    offset = center,
+                    source = intent.source,
+                    zIndex = (state.stickers.maxOfOrNull { it.zIndex } ?: 0) + 1
+                )
+            )
+        }
     }
 
-    fun Sticker.withRotation(newRotation: Float): Sticker = when (this) {
-        is BitmapSticker -> this.copy(rotation = newRotation)
+    private fun selectSticker(intent: EditorIntent.OnSelectImage) {
+        updateState { state ->
+            val newTop = (state.stickers.maxOfOrNull { it.zIndex } ?: 0) + 1
+            state.copy(
+                selectImageId = intent.selectImageId,
+                stickers = state.stickers.map { sticker ->
+                    if (sticker.id == intent.selectImageId) sticker.copy(zIndex = newTop)
+                    else sticker
+                }
+            )
+        }
     }
+
+    private fun moveSticker(intent: EditorIntent.OnMove) {
+        updateState { state ->
+            state.copy(stickers = state.stickers.map { sticker ->
+                if (sticker.id == intent.id) sticker.copy(offset = Offset(intent.x, intent.y))
+                else sticker
+            })
+        }
+    }
+
+    private fun removeSticker(intent: EditorIntent.OnRemove) {
+        updateState { state ->
+            state.copy(
+                stickers = state.stickers.filterNot { it.id == intent.id },
+                selectImageId = if (state.selectImageId == intent.id) null else state.selectImageId
+            )
+        }
+    }
+
+    private fun scaleSticker(intent: EditorIntent.OnScale) {
+        updateState { state ->
+            state.copy(stickers = state.stickers.map { sticker ->
+                if (sticker.id == intent.id) sticker.copy(scale = intent.scale.coerceIn(0.3f, 5f))
+                else sticker
+            })
+        }
+    }
+
+    private fun rotateSticker(intent: EditorIntent.OnRotate) {
+        updateState { state ->
+            state.copy(stickers = state.stickers.map { sticker ->
+                if (sticker.id == intent.id) sticker.copy(
+                    rotation = (sticker.rotation + intent.newRotation).mod(360f)
+                )
+                else sticker
+            })
+        }
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈 
- Resolved : #55 

## 작업 내용
스티커 리사이즈 조절 기능 개선 및 전체 구조 리팩토링 

## 스티커 편집 기능 개선
### 1. 기존 문제 
스티커의 위치 및 변경을 offset + x, y를 동시에 관리하고 있어서 발생했던 상태 불일치 
( 어떤 값은 x, y, 어떤 값은 offset ) 

  이미지 추가 -> 이미지 리사이즈 및 회전 
  순서대로 구현하다보니 덧붙이는 형태로 개발해서 생긴 문제 

### 2. 개선 방법 
- `Sticker.kt`  x, y 로 관리하는 코드 전체 제거하고 offset 으로 통일하여 상태 불일치 문제 해결
- Intent 단순화하는 구조로 수정 
- Component 도 단순화

## 이미지 저장 방법 수정 
    AS-IS   이미지 (bitmap ) + 스티커 ( bitmap List ) 를 Usecase에 전달하는 구조 
    TO-BE   Composable View를 캡쳐하여 Bitamap 으로 전환하여 Usecase에 전달하는 구조 

### 1. 기존 문제점 
1. 가로 사진일 경우 현재 보이는 뷰 + 스티커의 조합과 Bitmap 조합이 다르게 나올 수 있음
2. 도메인이 너무 많은 역할을 가지고 있었다. 

### 2. 해결 방법 이후 장점 
1. 현재 보이는 화면 기준으로 이미지를 생성 -> 깨비즈에서 의도한 기능과 일치 
2. UseCase 인증카드와 함께 사용할 수 있음 

## 🚨 참고 사항
<!-- 주의 깊게 봐야할 내용 --> 
<!-- 논의 내용 -->
<!-- 참고 자료들 리스트업 -->

이것 또한 늦어서 죄송합니다 🙇🏻‍♀️🙇🏻‍♀️

## 📷 스크린샷
|기능|
|:--:|
|<!-- 이미지 첨부 자리 -->|
